### PR TITLE
Adds an entry to cover CVE-2020-17526 for Apache Airflow.

### DIFF
--- a/flask_unsign_wordlist/wordlists/all.txt
+++ b/flask_unsign_wordlist/wordlists/all.txt
@@ -41665,3 +41665,4 @@
 '请填入豆瓣api secret'
 '◼︎◼︎◼︎◼︎◼︎◼︎'
 '��L���vl�6��Z5'
+'temporary_key'


### PR DESCRIPTION
CVE-2020-17526 is an issue in Airflow where they used `temporary_key` as the session secret for every Airflow instance. This adds this as an entry to the wordlist so this tool will catch it in the future.